### PR TITLE
Dimensions are not filled for movies

### DIFF
--- a/Classes/Helpers/VimeoHelper.php
+++ b/Classes/Helpers/VimeoHelper.php
@@ -192,6 +192,8 @@ class VimeoHelper extends AbstractOnlineMediaHelper {
 			if (!$file->getProperty('description')) {
 				$metadata['description'] = strip_tags($info['description']);
 			}
+			$metadata['width'] = (int) $info['width'];
+			$metadata['height'] = (int) $info['height'];
 			$metadata['duration'] = $info['duration'];
 			$metadata['source'] = 'Vimeo.com';
 		}

--- a/Classes/Helpers/YouTubeHelper.php
+++ b/Classes/Helpers/YouTubeHelper.php
@@ -128,12 +128,8 @@ class YouTubeHelper extends AbstractOnlineMediaHelper {
 		$oembed = $this->getYouTubeOembed($this->getOnlineMediaId($file));
 
 		if ($oembed) {
-			if (!$file->getProperty('width')) {
-				$metadata['width'] = (int) $oembed->width;
-			}
-			if (!$file->getProperty('height')) {
-				$metadata['height'] = (int) $oembed->height;
-			}
+			$metadata['width'] = (int) $oembed->width;
+			$metadata['height'] = (int) $oembed->height;
 		}
 
 		$metadata['type'] = File::FILETYPE_VIDEO;

--- a/Classes/Helpers/YouTubeHelper.php
+++ b/Classes/Helpers/YouTubeHelper.php
@@ -163,7 +163,7 @@ class YouTubeHelper extends AbstractOnlineMediaHelper {
 	 */
 	protected function getYouTubeOembed($videoId) {
 		$oembed = GeneralUtility::getUrl(
-			'http://www.youtube.com/oembed?url=' . urlencode(sprintf('http://www.youtube.com/watch?v=%s', $videoId)) . '&format=json'
+			'https://www.youtube.com/oembed?url=' . urlencode(sprintf('http://www.youtube.com/watch?v=%s', $videoId)) . '&format=json'
 		);
 		if ($oembed) {
 			$oembed = json_decode($oembed);


### PR DESCRIPTION
For calculating widths and heights in a gallery, like in Text and Media, the dimensions of movies are necessary. YouTube does not provide this data in gdata, as used in the YouTubeHelper, but does provide dimensions in oembed. Vimeo returns it out of the box.
